### PR TITLE
show errors, restoring functionality

### DIFF
--- a/vsh.v
+++ b/vsh.v
@@ -283,6 +283,11 @@ fn event(e &tui.Event, x voidptr) {
 					// run the command the user entered
 					// TODO: move this all to a function and make it more resilient
 					output := os.execute(cmd)
+					if output.exit_code != 0 {
+ 						buffer.put('\n$output.output')
+ 						buffer.put('v# ')
+ 						return
+ 					}
 
 					// only save the command to history if it's not a blank line
 					// (example: the user just pressing enter won't append blank lines to the history file)


### PR DESCRIPTION
This doesn't actually do anything for #25 but restores what was there in a new syntax after some v changes.

Signed-off-by: Jacob Salmela <me@jacobsalmela.com>