### PR TITLE
add back built-ins and add exit. (first pull to start implementing v coreutils)

### DIFF
--- a/vsh.v
+++ b/vsh.v
@@ -282,6 +282,12 @@ fn event(e &tui.Event, x voidptr) {
 					// if nothing was typed on the command line, return the prompt
 					buffer.put('\n')
 					buffer.put('v# ')
+				} else if cmd.split(' ')[0] == "cd" {
+					os.chdir(cmd.split(' ')[1])
+					buffer.put('v# ')
+				} else if cmd.split(' ')[0] == "pwd" {
+					buffer.put('\n$os.getwd()\n')
+					buffer.put('v# ')
 				} else {
 					// run the command the user entered
 					cmd_execute(mut hist_append, mut buffer, cmd)

--- a/vsh.v
+++ b/vsh.v
@@ -284,7 +284,7 @@ fn event(e &tui.Event, x voidptr) {
 					buffer.put('v# ')
 				} else if cmd.split(' ')[0] == "cd" {
 					os.chdir(cmd.split(' ')[1])
-					buffer.put('v# ')
+					buffer.put('\nv# ')
 				} else if cmd.split(' ')[0] == "pwd" {
 					buffer.put('\n$os.getwd()\n')
 					buffer.put('v# ')

--- a/vsh.v
+++ b/vsh.v
@@ -288,6 +288,8 @@ fn event(e &tui.Event, x voidptr) {
 				} else if cmd.split(' ')[0] == "pwd" {
 					buffer.put('\n$os.getwd()\n')
 					buffer.put('v# ')
+				} else if cmd.split(' ')[0] == "exit" {
+					exit(0)
 				} else {
 					// run the command the user entered
 					cmd_execute(mut hist_append, mut buffer, cmd)


### PR DESCRIPTION
It adds back the built-ins and fixes the missing exit command.  I think the only coreutil that we need to implement in this is pwd so we can put full functionality.  I'll open another pull to implement it if you want me to. 